### PR TITLE
workflow: Update comments and schedule for docs publishing.

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,12 +1,15 @@
 name: Documentation
-# This job builds and deploys documenation to github pages.
-# It runs on every push to master.
+# This workflow clones the tendermint/tendermint repository, builds its static
+# documentation, and publishes the results to GitHub Pages.
+# It runs on every push to the main branch, and every fifteen minutes.
+#
+# Note that this workflow does not respond to pushes on tendermint/tendermint.
 on:
   push:
     branches:
       - main
   schedule:
-    - cron: "* 0 * * *"
+    - cron: '*/15 * * * *'
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
The previous schedule requested a build every minute of the hour after midnight.
Given how long the site takes to build, that is probably excessive. 
Reduce it to every 15 minutes, and extend it throughout the day.

Also fix the branch name and a typo in the push comment.

Discovered while working on https://github.com/tendermint/tendermint/pull/7023.