### PR TITLE
build: squash history in the deploy branch

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -35,3 +35,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: ~/output
+          single-commit: true


### PR DESCRIPTION
There is no need to keep branch history for older deployed versions of the
site. Doing so causes a fresh clone of the repository to be > 3 GiB as of this
writing.

See: https://github.com/JamesIves/github-pages-deploy-action#optional-choices